### PR TITLE
Add `[sources]` to `docs/Project.toml`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,6 +7,9 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 TrixiBottomTopography = "86af9953-43df-404b-8eaa-d20d82623a82"
 TrixiShallowWater = "804cb1fc-5b08-4398-a671-a789bfe091b3"
 
+[sources.TrixiBottomTopography]
+path = ".."
+
 [compat]
 CairoMakie = "0.13, 0.15"
 Changelog = "1.1"


### PR DESCRIPTION
This should help avoid future flotsam compat bounds PRs from CompatHelper.